### PR TITLE
Forcing content type on the sendErrorResource the same way the sendResou...

### DIFF
--- a/src/Drahak/Restful/Application/UI/ResourcePresenter.php
+++ b/src/Drahak/Restful/Application/UI/ResourcePresenter.php
@@ -104,12 +104,6 @@ abstract class ResourcePresenter extends UI\Presenter implements IResourcePresen
 			// Create resource object
 			$this->resource = $this->resourceFactory->create();
 
-			// Check if Accept header is invalid
-			$accept = $this->getHttpRequest()->getHeader('Accept');
-			if (!$this->responseFactory->isAcceptable($accept)) {
-				throw new InvalidStateException('Cannot determine response with content type ' . $accept, 406);
-			}
-
 			// calls $this->validate<Action>()
 			$validationProcessed = $this->tryCall($this->formatValidateMethod($this->action), $this->params);
 


### PR DESCRIPTION
Hi,
I've run into the following problem - I am forcing the default contentType of API response by providing an explicit $contentType value to ResourcePresenter::sendResource($contentType).

However ResourcePresenter::sendErrorResource() method works differently and does not provide a way to force the content type and always relies on the Accept http headers only. This seems a bit unfortunate, thus I have prepared this pull request which unifies the way both methods work.

Btw, great library. :)