### PR TITLE
Default response content type when Accept header is missing

### DIFF
--- a/src/Drahak/Restful/Application/ResponseFactory.php
+++ b/src/Drahak/Restful/Application/ResponseFactory.php
@@ -205,6 +205,9 @@ class ResponseFactory extends Object implements IResponseFactory
 	{
 		$accept = explode(',', $contentType);
 		$acceptableTypes = array_keys($this->responses);
+		if(!$contentType) {
+			return $acceptableTypes[0];
+		}
 		foreach ($accept as $mimeType) {
 			if ($mimeType === '*/*') return $acceptableTypes[0];
 			foreach ($acceptableTypes as $formatMime) {


### PR DESCRIPTION
When Accept header is missing in request - response factory selects default response content type (same as with * / * Accept header)