### PR TITLE
NullMapper don't parse input data. 

### DIFF
--- a/src/Drahak/Restful/Mapping/NullMapper.php
+++ b/src/Drahak/Restful/Mapping/NullMapper.php
@@ -31,7 +31,7 @@ class NullMapper extends Object implements IMapper
 	 */
 	public function parse($data)
 	{
-		return $data;
+		return array();
 	}
 
 


### PR DESCRIPTION
NullMapper don't parse input data. Or else payload content types using NullMapper cannot be used to create input. For example when sending request with content type application/octet-stream (file in payload) NullMapper returns file content which then fails to merge to input data.