### PR TITLE
Fixed tests and added Travis CI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-libs
+libs/
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: php
+
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+
+env:
+  - TESTER_PHP_BIN="php-cgi"
+  - TESTER_PHP_BIN="php"
+
+matrix:
+  allow_failures:
+    - php: hhvm
+
+  exclude:
+    - env: TESTER_PHP_BIN="php"
+
+  include:
+    - php: hhvm
+      env: TESTER_PHP_BIN="php"
+
+before_install:
+  - composer self-update
+
+install:
+  - composer install --prefer-source --no-interaction
+
+before_script:
+  - mkdir tests/temp
+  - ./libs/bin/parallel-lint -e php,phpt --exclude libs .
+
+script:
+  - ./libs/bin/tester -p $TESTER_PHP_BIN ./tests/

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	},
 	"require-dev": {
 		"drahak/oauth2": "dev-master",
-		"nette/tester": "dev-master",
+		"nette/tester": "~1.3",
 		"janmarek/mockista": "dev-master"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,13 @@
 	"require": {
 		"php": ">= 5.3.0",
 
-		"nette/nette": "@dev"
+		"nette/nette": "~2.3"
 	},
 	"require-dev": {
 		"drahak/oauth2": "dev-master",
 		"nette/tester": "~1.3",
-		"janmarek/mockista": "dev-master"
+		"janmarek/mockista": "dev-master",
+		"jakub-onderka/php-parallel-lint": "~0.8"
 	},
 	"autoload": {
 		"psr-0": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "369b4d27a9ad8e653008919807092623",
+    "hash": "71d824f7009d778028d7b3e2e0561d7f",
     "packages": [
         {
             "name": "latte/latte",
@@ -771,40 +771,40 @@
         },
         {
             "name": "nette/nette",
-            "version": "dev-master",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/nette.git",
-                "reference": "dd83acebd56e43d6335d95483cf1cefc29f92d0f"
+                "reference": "0aeb94109a668ec6475a3288ef7e8d81ec1814ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/nette/zipball/dd83acebd56e43d6335d95483cf1cefc29f92d0f",
-                "reference": "dd83acebd56e43d6335d95483cf1cefc29f92d0f",
+                "url": "https://api.github.com/repos/nette/nette/zipball/0aeb94109a668ec6475a3288ef7e8d81ec1814ce",
+                "reference": "0aeb94109a668ec6475a3288ef7e8d81ec1814ce",
                 "shasum": ""
             },
             "require": {
-                "latte/latte": "@dev",
-                "nette/application": "@dev",
-                "nette/bootstrap": "@dev",
-                "nette/caching": "@dev",
-                "nette/component-model": "@dev",
-                "nette/database": "@dev",
-                "nette/deprecated": "@dev",
-                "nette/di": "@dev",
-                "nette/finder": "@dev",
-                "nette/forms": "@dev",
-                "nette/http": "@dev",
-                "nette/mail": "@dev",
-                "nette/neon": "@dev",
-                "nette/php-generator": "@dev",
-                "nette/reflection": "@dev",
-                "nette/robot-loader": "@dev",
-                "nette/safe-stream": "@dev",
-                "nette/security": "@dev",
-                "nette/tokenizer": "@dev",
-                "nette/utils": "@dev",
-                "tracy/tracy": "@dev"
+                "latte/latte": "2.3.0",
+                "nette/application": "2.3.1",
+                "nette/bootstrap": "2.3.0",
+                "nette/caching": "2.3.0",
+                "nette/component-model": "2.2.1",
+                "nette/database": "2.3.0",
+                "nette/deprecated": "2.2.1",
+                "nette/di": "2.3.0",
+                "nette/finder": "2.3.0",
+                "nette/forms": "2.3.0",
+                "nette/http": "2.3.0",
+                "nette/mail": "2.3.0",
+                "nette/neon": "2.3.0",
+                "nette/php-generator": "2.3.0",
+                "nette/reflection": "2.3.0",
+                "nette/robot-loader": "2.3.0",
+                "nette/safe-stream": "2.3.0",
+                "nette/security": "2.3.0",
+                "nette/tokenizer": "2.2.0",
+                "nette/utils": "2.3.0",
+                "tracy/tracy": "2.3.0"
             },
             "require-dev": {
                 "nette/tester": "~1.3"
@@ -847,7 +847,7 @@
                 "mvc",
                 "templating"
             ],
-            "time": "2015-02-25 16:28:06"
+            "time": "2015-02-25 22:49:12"
         },
         {
             "name": "nette/php-generator",
@@ -1353,6 +1353,53 @@
             "time": "2013-09-19 16:55:51"
         },
         {
+            "name": "jakub-onderka/php-parallel-lint",
+            "version": "v0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JakubOnderka/PHP-Parallel-Lint.git",
+                "reference": "2b242dcdbdd7369d2a746518ac31bb30c514b728"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JakubOnderka/PHP-Parallel-Lint/zipball/2b242dcdbdd7369d2a746518ac31bb30c514b728",
+                "reference": "2b242dcdbdd7369d2a746518ac31bb30c514b728",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "jakub-onderka/php-console-highlighter": "~0.3",
+                "nette/tester": "~1.3"
+            },
+            "suggest": {
+                "jakub-onderka/php-console-highlighter": "Highlight syntax in code snippet"
+            },
+            "bin": [
+                "parallel-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "./"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Onderka",
+                    "email": "jakub.onderka@gmail.com"
+                }
+            ],
+            "description": "This tool check syntax of PHP files about 20x faster than serial check.",
+            "homepage": "https://github.com/JakubOnderka/PHP-Parallel-Lint",
+            "time": "2014-10-05 10:19:39"
+        },
+        {
             "name": "janmarek/mockista",
             "version": "dev-master",
             "source": {
@@ -1466,7 +1513,6 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "nette/nette": 20,
         "drahak/oauth2": 20,
         "janmarek/mockista": 20
     },

--- a/composer.lock
+++ b/composer.lock
@@ -1,48 +1,823 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
-    "hash": "38a7a733aac115d058b04c83937f087e",
+    "hash": "369b4d27a9ad8e653008919807092623",
     "packages": [
+        {
+            "name": "latte/latte",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/latte.git",
+                "reference": "020300e124d8aa2fb324d5830ec4862b6b9ab1da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/latte/zipball/020300e124d8aa2fb324d5830ec4862b6b9ab1da",
+                "reference": "020300e124d8aa2fb324d5830ec4862b6b9ab1da",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.1"
+            },
+            "require-dev": {
+                "nette/tester": "~1.3"
+            },
+            "suggest": {
+                "ext-fileinfo": "to use filter |datastream",
+                "ext-mbstring": "to use filters like lower, upper, capitalize, ..."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Latte: the amazing template engine for PHP",
+            "homepage": "http://latte.nette.org",
+            "keywords": [
+                "templating",
+                "twig"
+            ],
+            "time": "2015-02-24 22:10:51"
+        },
+        {
+            "name": "nette/application",
+            "version": "v2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/application.git",
+                "reference": "6144b265234b31a48ca795e0efce392cfca1def7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/application/zipball/6144b265234b31a48ca795e0efce392cfca1def7",
+                "reference": "6144b265234b31a48ca795e0efce392cfca1def7",
+                "shasum": ""
+            },
+            "require": {
+                "nette/component-model": "~2.2",
+                "nette/di": "~2.3",
+                "nette/http": "~2.2",
+                "nette/reflection": "~2.2",
+                "nette/security": "~2.2",
+                "nette/utils": "~2.2",
+                "php": ">=5.3.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "latte/latte": "~2.3",
+                "nette/forms": "~2.2",
+                "nette/robot-loader": "~2.2",
+                "nette/tester": "~1.3"
+            },
+            "suggest": {
+                "latte/latte": "Allows using Latte in templates",
+                "nette/forms": "Allows to use Nette\\Application\\UI\\Form"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Application MVC Component",
+            "homepage": "http://nette.org",
+            "time": "2015-02-25 22:44:23"
+        },
+        {
+            "name": "nette/bootstrap",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/bootstrap.git",
+                "reference": "5b7c055f38e8d329bc8f4b4504899b5b39be5199"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/bootstrap/zipball/5b7c055f38e8d329bc8f4b4504899b5b39be5199",
+                "reference": "5b7c055f38e8d329bc8f4b4504899b5b39be5199",
+                "shasum": ""
+            },
+            "require": {
+                "nette/di": "~2.3",
+                "nette/utils": "~2.2",
+                "php": ">=5.3.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "latte/latte": "~2.2",
+                "nette/application": "~2.3",
+                "nette/caching": "~2.3",
+                "nette/database": "~2.3",
+                "nette/forms": "~2.3",
+                "nette/http": "~2.3",
+                "nette/mail": "~2.3",
+                "nette/robot-loader": "~2.2",
+                "nette/safe-stream": "~2.2",
+                "nette/security": "~2.3",
+                "nette/tester": "~1.3",
+                "tracy/tracy": "~2.3"
+            },
+            "suggest": {
+                "nette/robot-loader": "to use Configurator::createRobotLoader()",
+                "tracy/tracy": "to use Configurator::enableDebugger()"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Bootstrap",
+            "homepage": "http://nette.org",
+            "time": "2015-02-20 19:43:56"
+        },
+        {
+            "name": "nette/caching",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/caching.git",
+                "reference": "e9508220f5628d9ac075ec3c13ba1e053dbd7944"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/caching/zipball/e9508220f5628d9ac075ec3c13ba1e053dbd7944",
+                "reference": "e9508220f5628d9ac075ec3c13ba1e053dbd7944",
+                "shasum": ""
+            },
+            "require": {
+                "nette/finder": "~2.2",
+                "nette/utils": "~2.2",
+                "php": ">=5.3.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "latte/latte": "~2.3",
+                "nette/di": "~2.3",
+                "nette/tester": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Caching Component",
+            "homepage": "http://nette.org",
+            "time": "2015-02-18 02:23:54"
+        },
+        {
+            "name": "nette/component-model",
+            "version": "v2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/component-model.git",
+                "reference": "969caabb2c03b4f6556adf1b438ffb4d76c0cf38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/component-model/zipball/969caabb2c03b4f6556adf1b438ffb4d76c0cf38",
+                "reference": "969caabb2c03b4f6556adf1b438ffb4d76c0cf38",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "~2.2",
+                "php": ">=5.3.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/tester": "~1.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Component Model",
+            "homepage": "http://nette.org",
+            "time": "2015-02-06 14:13:18"
+        },
+        {
+            "name": "nette/database",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/database.git",
+                "reference": "9e939487553684074ca49428575ee518e94aaa4f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/database/zipball/9e939487553684074ca49428575ee518e94aaa4f",
+                "reference": "9e939487553684074ca49428575ee518e94aaa4f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pdo": "*",
+                "nette/caching": "~2.2",
+                "nette/utils": "~2.2",
+                "php": ">=5.3.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9.1",
+                "nette/di": "~2.3",
+                "nette/tester": "~1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Database Component",
+            "homepage": "http://nette.org",
+            "time": "2015-02-20 03:30:49"
+        },
+        {
+            "name": "nette/deprecated",
+            "version": "v2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/deprecated.git",
+                "reference": "ca8329b0b00bd930fdd79c268f1d1361ea978cb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/deprecated/zipball/ca8329b0b00bd930fdd79c268f1d1361ea978cb6",
+                "reference": "ca8329b0b00bd930fdd79c268f1d1361ea978cb6",
+                "shasum": ""
+            },
+            "require-dev": {
+                "latte/latte": "~2.2",
+                "nette/application": "~2.2",
+                "nette/bootstrap": "~2.2, >=2.2.1",
+                "nette/caching": "~2.2",
+                "nette/forms": "~2.2",
+                "nette/mail": "~2.2",
+                "nette/safe-stream": "~2.2",
+                "nette/tester": "~1.1",
+                "nette/utils": "~2.2",
+                "tracy/tracy": "~2.2"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ],
+                "files": [
+                    "src/loader.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "APIs and features removed from Nette Framework",
+            "homepage": "http://nette.org",
+            "time": "2015-01-31 14:17:44"
+        },
+        {
+            "name": "nette/di",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/di.git",
+                "reference": "440d9bab1857b34ce6d0c24e023748c012d53686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/di/zipball/440d9bab1857b34ce6d0c24e023748c012d53686",
+                "reference": "440d9bab1857b34ce6d0c24e023748c012d53686",
+                "shasum": ""
+            },
+            "require": {
+                "nette/neon": "~2.3",
+                "nette/php-generator": "~2.3",
+                "nette/utils": "~2.3",
+                "php": ">=5.3.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/tester": "~1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Dependency Injection Component",
+            "homepage": "http://nette.org",
+            "time": "2015-02-24 21:31:57"
+        },
+        {
+            "name": "nette/finder",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/finder.git",
+                "reference": "0eba793c90e236714b6f76474590d14d6bfe733a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/finder/zipball/0eba793c90e236714b6f76474590d14d6bfe733a",
+                "reference": "0eba793c90e236714b6f76474590d14d6bfe733a",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "~2.2",
+                "php": ">=5.3.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/tester": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Finder: Files Searching",
+            "homepage": "http://nette.org",
+            "time": "2015-02-17 20:36:43"
+        },
+        {
+            "name": "nette/forms",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/forms.git",
+                "reference": "8a7bedf704b2df1ac679a7f397832b2886ecb1a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/forms/zipball/8a7bedf704b2df1ac679a7f397832b2886ecb1a4",
+                "reference": "8a7bedf704b2df1ac679a7f397832b2886ecb1a4",
+                "shasum": ""
+            },
+            "require": {
+                "nette/component-model": "~2.2",
+                "nette/http": "~2.2",
+                "nette/utils": "~2.2",
+                "php": ">=5.3.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "latte/latte": "~2.3",
+                "nette/di": "~2.3",
+                "nette/tester": "~1.3",
+                "tracy/tracy": "~2.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Forms: greatly facilitates web forms",
+            "homepage": "http://nette.org",
+            "time": "2015-02-20 21:10:45"
+        },
+        {
+            "name": "nette/http",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/http.git",
+                "reference": "355aa597359084f1978f4eaaef94dbe33d2e8dff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/http/zipball/355aa597359084f1978f4eaaef94dbe33d2e8dff",
+                "reference": "355aa597359084f1978f4eaaef94dbe33d2e8dff",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "~2.2, >=2.2.2",
+                "php": ">=5.3.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/di": "~2.3",
+                "nette/tester": "~1.0"
+            },
+            "suggest": {
+                "ext-fileinfo": "to detect type of uploaded files"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette HTTP Component",
+            "homepage": "http://nette.org",
+            "time": "2015-02-25 00:17:52"
+        },
+        {
+            "name": "nette/mail",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/mail.git",
+                "reference": "19d7e1cb8f583c6fe49e896e9a341498decb385d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/mail/zipball/19d7e1cb8f583c6fe49e896e9a341498decb385d",
+                "reference": "19d7e1cb8f583c6fe49e896e9a341498decb385d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "nette/utils": "~2.2",
+                "php": ">=5.3.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/di": "~2.3",
+                "nette/tester": "~1.3"
+            },
+            "suggest": {
+                "ext-fileinfo": "to detect type of attached files"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Mail: Sending E-mails",
+            "homepage": "http://nette.org",
+            "time": "2015-02-24 22:24:13"
+        },
+        {
+            "name": "nette/neon",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/neon.git",
+                "reference": "c14c3ae106fbf11bef6dfc3ec7668c59bdd7f58e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/neon/zipball/c14c3ae106fbf11bef6dfc3ec7668c59bdd7f58e",
+                "reference": "c14c3ae106fbf11bef6dfc3ec7668c59bdd7f58e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=5.3.1"
+            },
+            "require-dev": {
+                "nette/tester": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette NEON: parser & generator for Nette Object Notation",
+            "homepage": "http://ne-on.org",
+            "time": "2015-02-17 21:10:16"
+        },
         {
             "name": "nette/nette",
             "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/nette.git",
-                "reference": "9d077ae6b8d49ed718e5ace6da007f876afeda13"
+                "reference": "dd83acebd56e43d6335d95483cf1cefc29f92d0f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/nette/zipball/9d077ae6b8d49ed718e5ace6da007f876afeda13",
-                "reference": "9d077ae6b8d49ed718e5ace6da007f876afeda13",
+                "url": "https://api.github.com/repos/nette/nette/zipball/dd83acebd56e43d6335d95483cf1cefc29f92d0f",
+                "reference": "dd83acebd56e43d6335d95483cf1cefc29f92d0f",
                 "shasum": ""
             },
             "require": {
-                "ext-iconv": "*",
-                "ext-tokenizer": "*",
-                "php": ">=5.3.0"
+                "latte/latte": "@dev",
+                "nette/application": "@dev",
+                "nette/bootstrap": "@dev",
+                "nette/caching": "@dev",
+                "nette/component-model": "@dev",
+                "nette/database": "@dev",
+                "nette/deprecated": "@dev",
+                "nette/di": "@dev",
+                "nette/finder": "@dev",
+                "nette/forms": "@dev",
+                "nette/http": "@dev",
+                "nette/mail": "@dev",
+                "nette/neon": "@dev",
+                "nette/php-generator": "@dev",
+                "nette/reflection": "@dev",
+                "nette/robot-loader": "@dev",
+                "nette/safe-stream": "@dev",
+                "nette/security": "@dev",
+                "nette/tokenizer": "@dev",
+                "nette/utils": "@dev",
+                "tracy/tracy": "@dev"
             },
             "require-dev": {
-                "nette/tester": "@dev"
-            },
-            "suggest": {
-                "ext-fileinfo": "*",
-                "ext-gd": "*",
-                "ext-mbstring": "*",
-                "ext-memcache": "*",
-                "ext-pdo": "*"
+                "nette/tester": "~1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.3-dev"
                 }
             },
             "autoload": {
-                "files": [
-                    "Nette/loader.php"
+                "classmap": [
+                    "Nette/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -66,18 +841,458 @@
             "keywords": [
                 "Forms",
                 "database",
-                "dbal",
                 "debugging",
                 "framework",
-                "images",
-                "latte",
                 "mailing",
-                "micro",
                 "mvc",
-                "neon",
                 "templating"
             ],
-            "time": "2013-08-12 15:35:56"
+            "time": "2015-02-25 16:28:06"
+        },
+        {
+            "name": "nette/php-generator",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/php-generator.git",
+                "reference": "bb8439b73fab9f403a7fa0d61e4c1913f75200ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/php-generator/zipball/bb8439b73fab9f403a7fa0d61e4c1913f75200ff",
+                "reference": "bb8439b73fab9f403a7fa0d61e4c1913f75200ff",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "~2.2",
+                "php": ">=5.3.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/tester": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette PHP Generator",
+            "homepage": "http://nette.org",
+            "time": "2015-02-18 17:11:05"
+        },
+        {
+            "name": "nette/reflection",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/reflection.git",
+                "reference": "08328bbd23323de285966dac7164f9ceb73cd77b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/reflection/zipball/08328bbd23323de285966dac7164f9ceb73cd77b",
+                "reference": "08328bbd23323de285966dac7164f9ceb73cd77b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "nette/caching": "~2.2",
+                "nette/utils": "~2.2",
+                "php": ">=5.3.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/di": "~2.3",
+                "nette/tester": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette PHP Reflection Component",
+            "homepage": "http://nette.org",
+            "time": "2015-02-16 15:33:50"
+        },
+        {
+            "name": "nette/robot-loader",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/robot-loader.git",
+                "reference": "0ae50d98dff4adbf1a0d756bf61f7f7c37d36651"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/robot-loader/zipball/0ae50d98dff4adbf1a0d756bf61f7f7c37d36651",
+                "reference": "0ae50d98dff4adbf1a0d756bf61f7f7c37d36651",
+                "shasum": ""
+            },
+            "require": {
+                "nette/caching": "~2.2",
+                "nette/finder": "~2.3",
+                "nette/utils": "~2.2",
+                "php": ">=5.3.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/tester": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette RobotLoader: comfortable autoloading",
+            "homepage": "http://nette.org",
+            "time": "2015-02-05 13:03:37"
+        },
+        {
+            "name": "nette/safe-stream",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/safe-stream.git",
+                "reference": "2881ad56880e9231a2456a7bf41b174df4ab320a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/safe-stream/zipball/2881ad56880e9231a2456a7bf41b174df4ab320a",
+                "reference": "2881ad56880e9231a2456a7bf41b174df4ab320a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/tester": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/loader.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette SafeStream: Atomic Operations",
+            "homepage": "http://nette.org",
+            "time": "2015-01-27 13:35:41"
+        },
+        {
+            "name": "nette/security",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/security.git",
+                "reference": "77a02c62029fee26e2bfb603ce8c5614fa012e26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/security/zipball/77a02c62029fee26e2bfb603ce8c5614fa012e26",
+                "reference": "77a02c62029fee26e2bfb603ce8c5614fa012e26",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "~2.2",
+                "php": ">=5.3.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/di": "~2.3",
+                "nette/http": "~2.3",
+                "nette/tester": "~1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Security: Access Control Component",
+            "homepage": "http://nette.org",
+            "time": "2015-02-24 20:35:28"
+        },
+        {
+            "name": "nette/tokenizer",
+            "version": "v2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/tokenizer.git",
+                "reference": "962b2b6f08c17018f5e37a85f8de631091eb3398"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/tokenizer/zipball/962b2b6f08c17018f5e37a85f8de631091eb3398",
+                "reference": "962b2b6f08c17018f5e37a85f8de631091eb3398",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/tester": "~1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Tokenizer",
+            "homepage": "http://nette.org",
+            "time": "2014-05-25 06:19:43"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/utils.git",
+                "reference": "29bfb4424689014e0749e14eef8de18c4b0fd020"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/utils/zipball/29bfb4424689014e0749e14eef8de18c4b0fd020",
+                "reference": "29bfb4424689014e0749e14eef8de18c4b0fd020",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/tester": "~1.0"
+            },
+            "suggest": {
+                "ext-gd": "to use Image",
+                "ext-iconv": "to use Strings::webalize() and toAscii()",
+                "ext-intl": "for script transliteration in Strings::webalize() and toAscii()",
+                "ext-mbstring": "to use Strings::lower() etc..."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Utility Classes",
+            "homepage": "http://nette.org",
+            "time": "2015-02-24 21:21:17"
+        },
+        {
+            "name": "tracy/tracy",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/tracy.git",
+                "reference": "0203000762fcadb4b00bcda5d5a2cf84348f3272"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/tracy/zipball/0203000762fcadb4b00bcda5d5a2cf84348f3272",
+                "reference": "0203000762fcadb4b00bcda5d5a2cf84348f3272",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.1"
+            },
+            "require-dev": {
+                "nette/di": "~2.3",
+                "nette/tester": "~1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src"
+                ],
+                "files": [
+                    "src/shortcuts.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Tracy: useful PHP debugger",
+            "homepage": "http://tracy.nette.org",
+            "keywords": [
+                "debug",
+                "debugger",
+                "nette"
+            ],
+            "time": "2015-02-24 21:00:38"
         }
     ],
     "packages-dev": [
@@ -87,12 +1302,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/drahak/OAuth2.git",
-                "reference": "72c82e626f7c8ded2ca4e5671cdbf37d7116b435"
+                "reference": "ceffa27b55d8637c123c884fc99cdc84c88a3995"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drahak/OAuth2/zipball/72c82e626f7c8ded2ca4e5671cdbf37d7116b435",
-                "reference": "72c82e626f7c8ded2ca4e5671cdbf37d7116b435",
+                "url": "https://api.github.com/repos/drahak/OAuth2/zipball/ceffa27b55d8637c123c884fc99cdc84c88a3995",
+                "reference": "ceffa27b55d8637c123c884fc99cdc84c88a3995",
                 "shasum": ""
             },
             "require": {
@@ -135,7 +1350,7 @@
                 "provider",
                 "server"
             ],
-            "time": "2013-07-09 20:40:57"
+            "time": "2013-09-19 16:55:51"
         },
         {
             "name": "janmarek/mockista",
@@ -143,12 +1358,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/janmarek/mockista.git",
-                "reference": "300c8bc71256cf04c426a5a37c0608577a7908b4"
+                "reference": "e182e1a953c99ff345a5e292e43c2a13db2fa5f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/janmarek/mockista/zipball/300c8bc71256cf04c426a5a37c0608577a7908b4",
-                "reference": "300c8bc71256cf04c426a5a37c0608577a7908b4",
+                "url": "https://api.github.com/repos/janmarek/mockista/zipball/e182e1a953c99ff345a5e292e43c2a13db2fa5f9",
+                "reference": "e182e1a953c99ff345a5e292e43c2a13db2fa5f9",
                 "shasum": ""
             },
             "require-dev": {
@@ -169,18 +1384,16 @@
             ],
             "authors": [
                 {
-                    "name": "Jan Marek",
-                    "email": "mail@janmarek.net",
-                    "homepage": "http://www.janmarek.net/",
-                    "role": "Author"
-                },
-                {
                     "name": "Jiří Knesl",
                     "homepage": "http://www.knesl.com/"
+                },
+                {
+                    "name": "Jan Marek",
+                    "homepage": "http://www.janmarek.net/"
                 }
             ],
             "description": "Mockista is library for mocking, which I've written, because I find mocking in PHPUnit awful.",
-            "homepage": "http://www.mockista.com/",
+            "homepage": "https://github.com/janmarek/mockista",
             "keywords": [
                 "BDD",
                 "TDD",
@@ -191,20 +1404,20 @@
                 "testing",
                 "tests"
             ],
-            "time": "2013-06-24 12:24:03"
+            "time": "2015-01-26 04:10:48"
         },
         {
             "name": "nette/tester",
-            "version": "dev-master",
+            "version": "v1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/tester.git",
-                "reference": "v0.9.3"
+                "reference": "2ce1cd9a6d7012ba059efa08613d5cd6e50c6560"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/tester/zipball/v0.9.3",
-                "reference": "v0.9.3",
+                "url": "https://api.github.com/repos/nette/tester/zipball/2ce1cd9a6d7012ba059efa08613d5cd6e50c6560",
+                "reference": "2ce1cd9a6d7012ba059efa08613d5cd6e50c6560",
                 "shasum": ""
             },
             "require": {
@@ -214,6 +1427,11 @@
                 "Tester/tester"
             ],
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "Tester/"
@@ -235,30 +1453,27 @@
                     "homepage": "http://nette.org/contributors"
                 }
             ],
-            "description": "An easy-to-use PHP Unit Testing framework.",
+            "description": "An easy-to-use PHP unit testing framework.",
             "homepage": "http://nette.org",
             "keywords": [
                 "nette",
                 "testing",
                 "unit"
             ],
-            "time": "2013-08-07 08:59:53"
+            "time": "2015-02-08 04:13:28"
         }
     ],
-    "aliases": [
-
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
         "nette/nette": 20,
         "drahak/oauth2": 20,
-        "nette/tester": 20,
         "janmarek/mockista": 20
     },
+    "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">= 5.3.0"
     },
-    "platform-dev": [
-
-    ]
+    "platform-dev": []
 }

--- a/src/Drahak/Restful/Validation/Validator.php
+++ b/src/Drahak/Restful/Validation/Validator.php
@@ -30,7 +30,7 @@ class Validator extends Object implements IValidator
 	 * Validate value for this rule
 	 * @param mixed $value
 	 * @param Rule $rule
-	 * @return void
+	 * @return bool
 	 *
 	 * @throws ValidationException
 	 * @throws InvalidStateException
@@ -45,13 +45,14 @@ class Validator extends Object implements IValidator
 			}
 			$params = array($value, $rule);
 			call_user_func_array($callback, $params);
-			return;
+			return TRUE;
 		}
 
 		$expression = $this->parseExpression($rule);
 		if (!Validators::is($value, $expression)) {
 			throw ValidationException::createFromRule($rule, $value);
 		}
+		return TRUE;
 	}
 
 	/**

--- a/tests/Tests/Drahak/Restful/Application/Events/MethodHandler.phpt
+++ b/tests/Tests/Drahak/Restful/Application/Events/MethodHandler.phpt
@@ -43,6 +43,7 @@ class MethodHandlerTest extends TestCase
 		parent::setUp();
 		$this->methodOptions = $this->mockista->create('Drahak\Restful\Application\MethodOptions');
 		$this->request = $this->mockista->create('Nette\Http\IRequest');
+		$this->request->method = 'METHOD';
 		$this->response = $this->mockista->create('Nette\Http\IResponse');
 		$this->application = $this->mockista->create('Nette\Application\Application');
 		$this->router = $this->mockista->create('Nette\Application\IRouter');
@@ -50,11 +51,17 @@ class MethodHandlerTest extends TestCase
 		$this->methodHandler = new MethodHandler($this->request, $this->response, $this->methodOptions);
 	}
 
+	protected function tearDown()
+	{
+		$this->mockista->assertExpectations();
+	}
+
 	public function testPassesIfRouterMatchesCurrentRequest()
 	{
 		$this->application->expects('getRouter')->once()->andReturn($this->router);
 		$this->router->expects('match')->once()->with($this->request)->andReturn(TRUE);
 		$this->methodHandler->run($this->application);
+		Assert::true(true);
 	}
 
 	public function testPassesIfRouterDoesntMatchButThereAreNoAvailableMethods()
@@ -66,6 +73,7 @@ class MethodHandlerTest extends TestCase
 		$this->methodOptions->expects('getOptions')->once()->with($url)->andReturn(array());
 
 		$this->methodHandler->run($this->application);
+		Assert::true(true);
 	}
 
 	public function testThrowsExceptionIfRouteDoesntMatchAndThereAreAvailableMethods()
@@ -85,6 +93,7 @@ class MethodHandlerTest extends TestCase
 	public function testPassesIfApplicationErrorAppearsButItIsNotBadRequestException()
 	{
 		$this->methodHandler->error($this->application, new \Exception('Something went wrong.'));
+		Assert::true(true);
 	}
 
 	public function testThrowsExceptionIfBadRequestExceptionAppears()

--- a/tests/Tests/Drahak/Restful/Application/ResponseFactory.phpt
+++ b/tests/Tests/Drahak/Restful/Application/ResponseFactory.phpt
@@ -16,7 +16,7 @@ use Tests\TestCase;
 /**
  * Test: Tests\Drahak\Restful\Application\ResponseFactory.
  *
- * @testCase Tests\Drahak\Restful\Application\ResponseFactoryTest
+ * @testCase
  * @author Drahomír Hanák
  * @package Tests\Drahak\Restful\Application
  */
@@ -276,7 +276,9 @@ class ResponseFactoryTest extends TestCase
 			->andReturn(FALSE);
 
 		$this->factory->prettyPrint = 'pretty';
-		$this->factory->create($this->resource);
+		$response = $this->factory->create($this->resource);
+
+		Assert::true($response instanceof TextResponse);
     }
 
     public function testAcceptContentTypeIfItsIsRegistered()

--- a/tests/Tests/Drahak/Restful/Http/InputFactory.phpt
+++ b/tests/Tests/Drahak/Restful/Http/InputFactory.phpt
@@ -38,6 +38,7 @@ class InputFactoryTest extends TestCase
     {
 		parent::setUp();
 		$this->request = $this->mockista->create('Nette\Http\IRequest');
+		$this->request->expects('getRawBody')->once();
 		$this->mapperContext = $this->mockista->create('Drahak\Restful\Mapping\MapperContext');
 		$this->validationScopeFactory = $this->mockista->create('Drahak\Restful\Validation\IValidationScopeFactory');
 		$this->inputFactory = new InputFactory($this->request, $this->mapperContext, $this->validationScopeFactory);

--- a/tests/Tests/Drahak/Restful/Http/ResponseFactory.phpt
+++ b/tests/Tests/Drahak/Restful/Http/ResponseFactory.phpt
@@ -87,7 +87,8 @@ class ResponseFactoryTest extends TestCase
 			->once()
 			->with('X-Total-Count', 100);
 
-		$this->factory->createHttpResponse(200);
+		$response = $this->factory->createHttpResponse(200);
+		Assert::true($response instanceof \Nette\Http\IResponse);
 	}
 
 	public function testCreateHttpResponseWithAllowedMethods()

--- a/tests/Tests/Drahak/Restful/Security/Process/OAuth2Authentication.phpt
+++ b/tests/Tests/Drahak/Restful/Security/Process/OAuth2Authentication.phpt
@@ -55,7 +55,7 @@ class OAuth2AuthenticationTest extends TestCase
 			->with($token)
 			->andReturn(array('access_token' => $token));
 
-		$this->process->authenticate($this->inputFake);
+		Assert::true($this->process->authenticate($this->inputFake));
     }
 
 	public function testThrowsExceptionWhenTokenIsNotFoundOnInput()

--- a/tests/Tests/Drahak/Restful/Security/Process/SecuredAuthentication.phpt
+++ b/tests/Tests/Drahak/Restful/Security/Process/SecuredAuthentication.phpt
@@ -53,7 +53,7 @@ class SecuredAuthenticationTest extends TestCase
 			->with($this->input)
 			->andReturn(TRUE);
 
-		$this->process->authenticate($this->input);
+		Assert::true($this->process->authenticate($this->input));
 	}
 
 }

--- a/tests/Tests/Drahak/Restful/Validation/Validator.phpt
+++ b/tests/Tests/Drahak/Restful/Validation/Validator.phpt
@@ -38,7 +38,7 @@ class ValidatorTest extends TestCase
     {
 		$this->rule->expression = IValidator::REGEXP;
 		$this->rule->argument = "/[a-z0-9]*/i";
-		$this->validator->validate('05das', $this->rule);
+		Assert::true($this->validator->validate('05das', $this->rule));
     }
 
 	public function testThrowsExceptionWhenRegularExpressionNotMatch()
@@ -63,7 +63,7 @@ class ValidatorTest extends TestCase
 	{
 		$this->rule->expression = IValidator::EQUAL;
 		$this->rule->argument = 10;
-		$this->validator->validate('10', $this->rule);
+		Assert::true($this->validator->validate('10', $this->rule));
 	}
 
 	public function testThrowsExceptionWhenValuesAreNotSame()
@@ -78,7 +78,7 @@ class ValidatorTest extends TestCase
 	public function testValidateEmailExpression()
 	{
 		$this->rule->expression = IValidator::EMAIL;
-		$this->validator->validate('test@domain.com', $this->rule);
+		Assert::true($this->validator->validate('test@domain.com', $this->rule));
 	}
 
 	public function testThrowsExceptionWhenEmailIsInvalid()
@@ -92,7 +92,7 @@ class ValidatorTest extends TestCase
 	public function testValidateUrl()
 	{
 		$this->rule->expression = IValidator::URL;
-		$this->validator->validate('http://www.domain.com', $this->rule);
+		Assert::true($this->validator->validate('http://www.domain.com', $this->rule));
 	}
 
 	public function testThrowsExceptionWhenUrlIsInvalid()
@@ -107,7 +107,7 @@ class ValidatorTest extends TestCase
 	{
 		$this->rule->expression = IValidator::MIN_LENGTH;
 		$this->rule->argument = 10;
-		$this->validator->validate('asdasfdsb515sdvbsbf', $this->rule);
+		Assert::true($this->validator->validate('asdasfdsb515sdvbsbf', $this->rule));
 	}
 
 	public function testThrowsExceptionWhenStingLengthIsTooShort()
@@ -123,35 +123,35 @@ class ValidatorTest extends TestCase
 	{
 		$this->rule->expression = IValidator::MAX_LENGTH;
 		$this->rule->argument = 10;
-		$this->validator->validate('asdasd', $this->rule);
+		Assert::true($this->validator->validate('asdasd', $this->rule));
 	}
 
 	public function testIsNumberWithinRange()
 	{
 		$this->rule->expression = IValidator::RANGE;
 		$this->rule->argument = array(10, 20);
-		$this->validator->validate(15, $this->rule);
+		Assert::true($this->validator->validate(15, $this->rule));
 	}
 
 	public function testIsNumberBiggerThenGiven()
 	{
 		$this->rule->expression = IValidator::RANGE;
 		$this->rule->argument = array(10, NULL);
-		$this->validator->validate(15, $this->rule);
+		Assert::true($this->validator->validate(15, $this->rule));
 	}
 
 	public function testIsNumberLowerThenGiven()
 	{
 		$this->rule->expression = IValidator::RANGE;
 		$this->rule->argument = array(NULL, 10);
-		$this->validator->validate(5, $this->rule);
+		Assert::true($this->validator->validate(5, $this->rule));
 	}
 
 	public function testIsRealNumber()
 	{
 		$this->rule->expression = IValidator::RANGE;
 		$this->rule->argument = array(NULL, NULL);
-		$this->validator->validate(5, $this->rule);
+		Assert::true($this->validator->validate(5, $this->rule));
 	}
 
 	public function testRangeRuleThrowsExceptionIfValueIsNotOfNumericType()
@@ -185,7 +185,7 @@ class ValidatorTest extends TestCase
 	{
 		$this->rule->expression = IValidator::LENGTH;
 		$this->rule->argument = array(5, 10);
-		$this->validator->validate('ad6as46', $this->rule);
+		Assert::true($this->validator->validate('ad6as46', $this->rule));
 	}
 
 	public function testThrowsExceptionWhenStringLegthIsOutOfRange()
@@ -200,7 +200,7 @@ class ValidatorTest extends TestCase
 	public function testValidateIntegerValue()
 	{
 		$this->rule->expression = IValidator::INTEGER;
-		$this->validator->validate(456, $this->rule);
+		Assert::true($this->validator->validate(456, $this->rule));
 	}
 
 	public function testThrowsExceptionWhenValueIsNotAnInteger()
@@ -214,7 +214,7 @@ class ValidatorTest extends TestCase
 	public function testValidateFloatValue()
 	{
 		$this->rule->expression = IValidator::FLOAT;
-		$this->validator->validate(45.45698, $this->rule);
+		Assert::true($this->validator->validate(45.45698, $this->rule));
 	}
 
 	public function testThrowsExceptionWhenValueIsNotFloat()
@@ -228,7 +228,7 @@ class ValidatorTest extends TestCase
 	public function testValidateNumericValue()
 	{
 		$this->rule->expression = IValidator::NUMERIC;
-		$this->validator->validate('45.45698', $this->rule);
+		Assert::true($this->validator->validate('45.45698', $this->rule));
 	}
 
 	public function testThrowsExceptionWhenValueIsNotNumeric()
@@ -242,19 +242,19 @@ class ValidatorTest extends TestCase
 	public function testValidateUuid()
 	{
 		$this->rule->expression = IValidator::UUID;
-		$this->validator->validate('bfc5b0f9-a33a-4bf5-8745-0701114ce4f3', $this->rule);
+		Assert::true($this->validator->validate('bfc5b0f9-a33a-4bf5-8745-0701114ce4f3', $this->rule));
 	}
 
 	public function testPassRequiredRuleValidationIfFieldIsNotNull()
 	{
 		$this->rule->expression = IValidator::REQUIRED;
-		$this->validator->validate('a', $this->rule);
+		Assert::true($this->validator->validate('a', $this->rule));
 	}
 
 	public function testPassRequiredRuleValidationIfFieldIsZero()
 	{
 		$this->rule->expression = IValidator::REQUIRED;
-		$this->validator->validate(0, $this->rule);
+		Assert::true($this->validator->validate(0, $this->rule));
 	}
 
 	public function testThrowsValidationExceptionIfRequiredFiledIsNull()
@@ -288,7 +288,7 @@ class ValidatorTest extends TestCase
 		$this->rule->argument = function($value) {
 			return true;
 		};
-		$this->validator->validate('test', $this->rule);
+		Assert::true($this->validator->validate('test', $this->rule));
 	}
 
 	public function testThrowsValidationExceptionIfCallbackValidatorResurnsFalse()

--- a/tests/Tests/bootstrap.php
+++ b/tests/Tests/bootstrap.php
@@ -6,7 +6,7 @@ if (@!include __DIR__ . '/../../libs/autoload.php') {
 require_once __DIR__ . '/TestCase.php';
 
 // configure environment
-Tester\Helpers::setup();
+Tester\Environment::setup();
 class_alias('Tester\Assert', 'Assert');
 date_default_timezone_set('Europe/Prague');
 

--- a/tests/run.bat
+++ b/tests/run.bat
@@ -1,9 +1,0 @@
-@ECHO OFF
-
-IF NOT EXIST "%~dp0..\libs\nette\tester" (
-	ECHO Nette Tester is missing. You can install it using Composer:
-	ECHO php composer.phar update --dev
-	EXIT /B 2
-)
-
-php.exe -n "%~dp0..\libs\nette\tester\Tester\tester.php" -p php-cgi.exe -c "%~dp0php-win.ini" -j 30 -log "%~dp0test.log" %*

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-php -c /etc/php5/apache2/php.ini ./libs/nette/tester/Tester/tester.php -c /etc/php5/apache2/php.ini ./tests


### PR DESCRIPTION
Changelog:
- Put tests on a diet as they weren't able to run. Now, they are.
- Said goodbye to `tests/run.*`. It was an obsolete way of running `Nette\Tester` tests.
- Updated old versions of dependencies in `composer.json`. It was time to move on.
- Added [Travis CI](https://travis-ci.org/klimesf/Restful) integration. Please, consider enabling it.