### PR TITLE
Composer: Restful now requires Nette ~2.0 instead of ~2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
 	},
 	"require": {
 		"php": ">= 5.3.0",
-
-		"nette/nette": "~2.3"
+		"nette/nette": "~2.0"
 	},
 	"require-dev": {
 		"drahak/oauth2": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "71d824f7009d778028d7b3e2e0561d7f",
+    "hash": "60dd7fb0d4d77875fafbdbaec232da00",
     "packages": [
         {
             "name": "latte/latte",


### PR DESCRIPTION
I introduced a Composer BC break in the last PR, this should fix it.