### PR TITLE
Nette 2.3 compatibility fix: Request raw body

### DIFF
--- a/src/Drahak/Restful/Http/ApiRequestFactory.php
+++ b/src/Drahak/Restful/Http/ApiRequestFactory.php
@@ -40,7 +40,8 @@ class ApiRequestFactory
 
 		return new Request(
 			$url, NULL, $request->getPost(), $request->getFiles(), $request->getCookies(), $request->getHeaders(),
-			$this->getPreferredMethod($request), $request->getRemoteAddress()
+			$this->getPreferredMethod($request), $request->getRemoteAddress(), null,
+			function () use ($request) { return $request->getRawBody(); }
 		);
 	}
 


### PR DESCRIPTION
ApiRequestFactory has to pass callback to load raw body to created request