### PR TITLE
use NullResponse when "204 No content"

### DIFF
--- a/src/Drahak/Restful/Application/ResponseFactory.php
+++ b/src/Drahak/Restful/Application/ResponseFactory.php
@@ -168,6 +168,7 @@ class ResponseFactory extends Object implements IResponseFactory
 
 		if (!$resource->getData()) {
 			$this->response->setCode(204); // No content
+			return new $this->responses[IResource::NULL];
 		}
 
 		$responseClass = $this->responses[$contentType];


### PR DESCRIPTION
i had trouble with empty response ("204 no content" http code), because resource was set to an empty array and the TextResponse (default for JSON) outputted "[]", but there should be no output at all. This fixed it for me.

Reference to the RFC2616:
10.2.5 204 No Content
   The server has fulfilled the request but does not need to return an
   entity-body, and might want to return updated metainformation. The
   response MAY include new or updated metainformation in the form of
   entity-headers, which if present SHOULD be associated with the
   requested variant.

   If the client is a user agent, it SHOULD NOT change its document view
   from that which caused the request to be sent. This response is
   primarily intended to allow input for actions to take place without
   causing a change to the user agent's active document view, although
   any new or updated metainformation SHOULD be applied to the document
   currently in the user agent's active view.

   The 204 response MUST NOT include a message-body, and thus is always
   terminated by the first empty line after the header fields.