### PR TITLE
Replace nette/nette dependency with actual dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,16 @@
 	},
 	"require": {
 		"php": ">= 5.3.0",
-		"nette/nette": "~2.0"
+		"nette/application": "~2.0",
+		"nette/bootstrap": "~2.0",
+		"nette/caching": "~2.0",
+		"nette/deprecated": "~2.0",
+		"nette/di": "~2.0",
+		"nette/http": "~2.0",
+		"nette/reflection": "~2.0",
+		"nette/robot-loader": "~2.0",
+		"nette/security": "~2.0",
+		"nette/utils": "~2.0"
 	},
 	"require-dev": {
 		"drahak/oauth2": "dev-master",


### PR DESCRIPTION
I replaced nette/nette dependency with the actual dependencies (based on the `use` namespace statements in the classes). This seemed to fix some rather obscure composer error messages I was having recently.

Note that I had to add the `nette/deprecated` dependency, because the following classes are used:

    Nette\Diagnostics\Debugger
    Nette\Diagnostics\IBarPanel
    Nette\Templating\Helpers

I also found the `use Nette\Forms\Form` declaration which, in fact, was not used in the code (not fixed in this PR).