### PR TITLE
bug fix - don't try to create paginator if limit is 0

### DIFF
--- a/src/Drahak/Restful/Utils/RequestFilter.php
+++ b/src/Drahak/Restful/Utils/RequestFilter.php
@@ -148,6 +148,12 @@ class RequestFilter extends Object
 			);
 		}
 
+		if ($limit == 0) {
+			throw new InvalidStateException(
+				'Pagination limit cannot be zero'
+			);
+		}
+
 		$paginator = new Paginator();
 		$paginator->setItemsPerPage($limit);
 		$paginator->setPage(floor($offset/$limit)+1);


### PR DESCRIPTION
Throws division by zero before reaching validation method