### PR TITLE
Update ApiRequestFactory.php

### DIFF
--- a/src/Drahak/Restful/Http/ApiRequestFactory.php
+++ b/src/Drahak/Restful/Http/ApiRequestFactory.php
@@ -30,7 +30,7 @@ class ApiRequestFactory
 
 	/**
 	 * Create API HTTP request 
-	 * @return Nette\Http\IRequest 
+	 * @return IRequest 
 	 */
 	public function createHttpRequest()
 	{


### PR DESCRIPTION
Fix for Nette 2.4 service container (bad usage of Nette namespace without leading \. This leads to Nette search for undefined class Drahak\Restful\Http\Nette\Http\IRequest)