### PR TITLE
Remove \Exception from error handlers type hints (PHP7 support)

### DIFF
--- a/src/Drahak/Restful/Application/Events/MethodHandler.php
+++ b/src/Drahak/Restful/Application/Events/MethodHandler.php
@@ -57,9 +57,9 @@ class MethodHandler extends Object
 	/**
 	 * On application error
 	 * @param  Application $application 
-	 * @param  Exception   $e           
+	 * @param  \Exception|\Throwable $e
 	 */
-	public function error(Application $application, \Exception $e)
+	public function error(Application $application,$e)
 	{
 		if ($e instanceof NetteBadRequestException && $e->getCode() === 404) {
 			$this->checkAllowedMethods();

--- a/src/Drahak/Restful/Application/UI/ResourcePresenter.php
+++ b/src/Drahak/Restful/Application/UI/ResourcePresenter.php
@@ -175,16 +175,24 @@ abstract class ResourcePresenter extends UI\Presenter implements IResourcePresen
 
 	/**
 	 * Create error response from exception
-	 * @param \Exception $e
+	 * @param \Exception|\Throwable $e
 	 * @return \Drahak\Restful\IResource
 	 */ 
-	protected function createErrorResource(\Exception $e)
+	protected function createErrorResource($e)
 	{
-		$resource = $this->resourceFactory->create(array(
-			'code' => $e->getCode(),
-			'status' => 'error',
-			'message' => $e->getMessage()
-		));
+	    if ($e instanceof \Exception || $e instanceof \Throwable) {
+            $resource = $this->resourceFactory->create(array(
+                'code' => $e->getCode(),
+                'status' => 'error',
+                'message' => $e->getMessage()
+            ));
+        } else {
+            $resource = $this->resourceFactory->create(array(
+                'code' => 500,
+                'status' => 'error',
+                'message' => (string)$e,
+            ));
+        }
 		
 		if (isset($e->errors) && $e->errors) {
 			$resource->errors = $e->errors;
@@ -195,9 +203,9 @@ abstract class ResourcePresenter extends UI\Presenter implements IResourcePresen
 
 	/**
 	 * Send error resource to output
-	 * @param \Exception $e
+	 * @param \Exception|\Throwable $e
 	 */
-	protected function sendErrorResource(\Exception $e, $contentType = NULL)
+	protected function sendErrorResource($e, $contentType = NULL)
 	{
 		/** @var Request $request */
 		$request = $this->getHttpRequest();

--- a/src/Drahak/Restful/Application/exceptions.php
+++ b/src/Drahak/Restful/Application/exceptions.php
@@ -22,10 +22,10 @@ class BadRequestException extends Nette\Application\BadRequestException
 	/**
 	 * Is thrown when trying to reach secured resource without authentication
 	 * @param string $message
-	 * @param \Exception $previous
+	 * @param \Exception|\Throwable $previous
 	 * @return BadRequestException
 	 */
-	public static function unauthorized($message = '', \Exception $previous = NULL)
+	public static function unauthorized($message = '', $previous = NULL)
 	{
 		return new self($message, 401, $previous);
 	}
@@ -33,10 +33,10 @@ class BadRequestException extends Nette\Application\BadRequestException
 	/**
 	 * Is thrown when access to this resource is forbidden
 	 * @param string $message
-	 * @param \Exception $previous
+	 * @param \Exception|\Throwable $previous
 	 * @return BadRequestException
 	 */
-	public static function forbidden($message = '', \Exception $previous = NULL)
+	public static function forbidden($message = '', $previous = NULL)
 	{
 		return new self($message, 403, $previous);
 	}
@@ -44,10 +44,10 @@ class BadRequestException extends Nette\Application\BadRequestException
 	/**
 	 * Is thrown when resource's not found
 	 * @param string $message
-	 * @param \Exception $previous
+	 * @param \Exception|\Throwable $previous
 	 * @return BadRequestException
 	 */
-	public static function notFound($message = '', \Exception $previous = NULL)
+	public static function notFound($message = '', $previous = NULL)
 	{
 		return new self($message, 404, $previous);
 	}
@@ -55,10 +55,10 @@ class BadRequestException extends Nette\Application\BadRequestException
 	/**
 	 * Is thrown when request method (e.g. POST or PUT) is not allowed for this resource
 	 * @param string $message
-	 * @param \Exception $previous
+	 * @param \Exception|\Throwable $previous
 	 * @return BadRequestException
 	 */
-	public static function methodNotSupported($message = '', \Exception $previous = NULL)
+	public static function methodNotSupported($message = '', $previous = NULL)
 	{
 		return new self($message, 405, $previous);
 	}
@@ -66,10 +66,10 @@ class BadRequestException extends Nette\Application\BadRequestException
 	/**
 	 * Is thrown when this resource is not no longer available (e.g. with new API version)
 	 * @param string $message
-	 * @param \Exception $previous
+	 * @param \Exception|\Throwable $previous
 	 * @return BadRequestException
 	 */
-	public static function gone($message = '', \Exception $previous = NULL)
+	public static function gone($message = '', $previous = NULL)
 	{
 		return new self($message, 410, $previous);
 	}
@@ -77,10 +77,10 @@ class BadRequestException extends Nette\Application\BadRequestException
 	/**
 	 * Is thrown when incorrect (or unknown) Content-Type was provided in request
 	 * @param string $message
-	 * @param \Exception $previous
+	 * @param \Exception|\Throwable $previous
 	 * @return BadRequestException
 	 */
-	public static function unsupportedMediaType($message = '', \Exception $previous = NULL)
+	public static function unsupportedMediaType($message = '', $previous = NULL)
 	{
 		return new self($message, 415, $previous);
 	}
@@ -89,10 +89,10 @@ class BadRequestException extends Nette\Application\BadRequestException
 	 * Is thrown when validation problem appears
 	 * @param Error[] $errors during validation
 	 * @param string $message
-	 * @param \Exception $previous
+	 * @param \Exception|\Throwable $previous
 	 * @return BadRequestException
 	 */
-	public static function unprocessableEntity(array $errors, $message = '', \Exception $previous = NULL)
+	public static function unprocessableEntity(array $errors, $message = '', $previous = NULL)
 	{
 		$e = new self($message, 422, $previous);
 		$e->errors = $errors;
@@ -102,10 +102,10 @@ class BadRequestException extends Nette\Application\BadRequestException
 	/**
 	 * Is thrown to reject request due to rate limiting
 	 * @param string $message
-	 * @param \Exception $previous
+	 * @param \Exception|\Throwable $previous
 	 * @return BadRequestException
 	 */
-	public static function tooManyRequests($message = '', \Exception $previous = NULL)
+	public static function tooManyRequests($message = '', $previous = NULL)
 	{
 		return new self($message, 429, $previous);
 	}


### PR DESCRIPTION
Remove \Exception type hint from error handlers, as it's not useable with PHP7, where \Error exists as sibiling of \Exception with \Throwable parent.

To support both PHP versions (5 and 7) is not possible to use any of typehint, when expecting \Exception or \Throwable.

My suggestion in this commit is to remove typehints and keep them only in phpdoc as Tracy does.