### PR TITLE
Update InputFactory.php

### DIFF
--- a/src/Drahak/Restful/Http/InputFactory.php
+++ b/src/Drahak/Restful/Http/InputFactory.php
@@ -66,7 +66,7 @@ class InputFactory extends Object
 		$urlQuery = (array)$this->httpRequest->getQuery();
 		$requestBody = $this->parseRequestBody();
 
-		return array_merge($urlQuery, $requestBody, $postQuery);
+		return array_merge($urlQuery, $postQuery, $requestBody);	// $requestBody must be the last one!!!
 	}
 
 	/**


### PR DESCRIPTION
This update fixes incorrect parsing of input data sent via JSON in request body.

Since httpRequest->getPost() also get the request body but mismatching data types, the correct JSON decoded array is destroyed.