### PR TITLE
Added test for ParseNumericValue method, change numeric validating be…

### DIFF
--- a/src/Drahak/Restful/Validation/Field.php
+++ b/src/Drahak/Restful/Validation/Field.php
@@ -2,7 +2,6 @@
 namespace Drahak\Restful\Validation;
 
 use Nette\Object;
-use Nette\Utils\Validators;
 
 /**
  * Validation field
@@ -150,10 +149,10 @@ class Field extends Object implements IField
 	 * @param mixed $value
 	 * @return mixed
 	 */
-	protected function parseNumericValue($value)
+	public function parseNumericValue($value)
 	{
-		if (Validators::isNumericInt($value)) return (int)$value;
-		if (Validators::isNumeric($value)) return (float)$value;
+		if (filter_var($value, FILTER_VALIDATE_INT)) return (int)$value;
+		if (filter_var($value, FILTER_VALIDATE_FLOAT)) return (float)$value;
 		return $value;
 	}
 

--- a/tests/Tests/Drahak/Restful/Validation/Field.phpt
+++ b/tests/Tests/Drahak/Restful/Validation/Field.phpt
@@ -109,5 +109,13 @@ class FieldTest extends TestCase
 		Assert::false($required);
 	}
 
+	public function testParseNumericValue()
+	{
+		Assert::true(is_int($this->field->parseNumericValue("2147483647"))); //maximum int value
+		Assert::same($this->field->parseNumericValue("2147483648"), 2147483648); //float
+		Assert::false(is_int($this->field->parseNumericValue("2147483648")));
+		Assert::true(is_float($this->field->parseNumericValue("2147483647.01")));
+		Assert::true(is_float($this->field->parseNumericValue("-2147483647.01")));
+	}
 }
 \run(new FieldTest());


### PR DESCRIPTION
…caues nette\utils has bug

Objevil jsem bug v nette\utils, Validators::isNumericInt, vraci true i presto ze je mu zaslano cislo vetsi nez je maximalni hodnota int. 
Teoreticky to bug neni, ale potom metoda parseNumericValue povazuje cislo float za int a tak ho pretypuje, vse se zda funkcni, jen s tim rozdilem, ze se mi vrati uplne jine cislo ne bylo zadano.Vzdy maximalni hodnota int. 
Nahradil jsem nette validaci, rucni a dopsal test na parseNumericValue (proto je public)