### PR TITLE
composer: allow Nette 3.0, RobotLoader is already out

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,16 @@
 	},
 	"require": {
 		"php": ">= 5.3.0",
-		"nette/application": "~2.0",
-		"nette/bootstrap": "~2.0",
-		"nette/caching": "~2.0",
-		"nette/deprecated": "~2.0",
-		"nette/di": "~2.0",
-		"nette/http": "~2.0",
-		"nette/reflection": "~2.0",
-		"nette/robot-loader": "~2.0",
-		"nette/security": "~2.0",
-		"nette/utils": "~2.0"
+		"nette/application": "~2.0|~3.0",
+		"nette/bootstrap": "~2.0|~3.0",
+		"nette/caching": "~2.0|~3.0",
+		"nette/deprecated": "~2.0|~3.0",
+		"nette/di": "~2.0|~3.0",
+		"nette/http": "~2.0|~3.0",
+		"nette/reflection": "~2.0|~3.0",
+		"nette/robot-loader": "~2.0|~3.0",
+		"nette/security": "~2.0|~3.0",
+		"nette/utils": "~2.0|~3.0"
 	},
 	"require-dev": {
 		"drahak/oauth2": "dev-master",


### PR DESCRIPTION
This would be resolved then:

![image](https://cloud.githubusercontent.com/assets/924196/25896398/4683a0b6-3584-11e7-93b9-c6e4386f1b14.png)
