### PR TITLE
Switched from Nette\Object to Nette\SmartObject - PHP 7.2 compatibility

### DIFF
--- a/src/Drahak/Restful/Application/CachedRouteListFactory.php
+++ b/src/Drahak/Restful/Application/CachedRouteListFactory.php
@@ -4,7 +4,7 @@ namespace Drahak\Restful\Application;
 use Drahak\Restful\Application\Routes\ResourceRouteList;
 use Nette\Caching\Cache;
 use Nette\Caching\IStorage;
-use Nette\Object;
+use Nette\SmartObject;
 use Nette\Utils\Finder;
 
 /**
@@ -12,8 +12,10 @@ use Nette\Utils\Finder;
  * @package Drahak\Restful\Application\Routes
  * @author Drahomír Hanák
  */
-final class CachedRouteListFactory extends Object implements IRouteListFactory
+final class CachedRouteListFactory implements IRouteListFactory
 {
+
+    use SmartObject;
 
 	/** Cache name */
 	const CACHE_NAME = 'resourceRouteList';

--- a/src/Drahak/Restful/Application/Events/MethodHandler.php
+++ b/src/Drahak/Restful/Application/Events/MethodHandler.php
@@ -3,21 +3,22 @@ namespace Drahak\Restful\Application\Events;
 
 use Drahak\Restful\Application\MethodOptions;
 use Drahak\Restful\Application\BadRequestException;
-use Drahak\Restful\Application\Routes\ResourceRoute;
 use Drahak\Restful\Http\Request;
 use Nette\Application\Application;
 use Nette\Application\BadRequestException as NetteBadRequestException;
 use Nette\Http\IRequest;
 use Nette\Http\IResponse;
-use Nette\Object;
+use Nette\SmartObject;
 
 /**
  * MethodHandler
  * @package Drahak\Restful\Application
  * @author Drahomír Hanák
  */
-class MethodHandler extends Object
+class MethodHandler
 {
+
+    use SmartObject;
 
 	/** @var IRequest */
 	private $request;

--- a/src/Drahak/Restful/Application/MethodOptions.php
+++ b/src/Drahak/Restful/Application/MethodOptions.php
@@ -6,16 +6,17 @@ use Nette\Http\Url;
 use Nette\Http\UrlScript;
 use Nette\Http\Request;
 use Nette\Http\IRequest;
+use Nette\SmartObject;
 use Traversable;
-use Nette\Object;
 
 /**
  * MethodOptions
  * @package Drahak\Restful\Application
  * @author Drahomír Hanák
  */
-class MethodOptions extends Object
-{
+class MethodOptions {
+
+    use SmartObject;
 
 	/** @var IRouter */
 	private $router;

--- a/src/Drahak/Restful/Application/ResponseFactory.php
+++ b/src/Drahak/Restful/Application/ResponseFactory.php
@@ -2,25 +2,28 @@
 namespace Drahak\Restful\Application;
 
 use Drahak\Restful\Application\Responses\BaseResponse;
-use Drahak\Restful\Application\Responses\NullResponse;
 use Drahak\Restful\InvalidArgumentException;
 use Drahak\Restful\InvalidStateException;
 use Drahak\Restful\IResource;
 use Drahak\Restful\Mapping\MapperContext;
-use Drahak\Restful\Utils\RequestFilter;
+use Nette\SmartObject;
 use Nette\Utils\Strings;
 use Nette\Http\IResponse;
 use Nette\Http\IRequest;
-use Nette\Http\Url;
-use Nette\Object;
 
 /**
  * REST ResponseFactory
  * @package Drahak\Restful
  * @author Drahomír Hanák
+ *
+ * @property string $jsonp
+ * @property-write string $prettyPrintKey
+ * @property-write bool $prettyPrint
  */
-class ResponseFactory extends Object implements IResponseFactory
+class ResponseFactory implements IResponseFactory
 {
+
+    use SmartObject;
 
 	/** @var IResponse */
 	private $response;

--- a/src/Drahak/Restful/Application/Responses/BaseResponse.php
+++ b/src/Drahak/Restful/Application/Responses/BaseResponse.php
@@ -2,11 +2,9 @@
 namespace Drahak\Restful\Application\Responses;
 
 use Drahak;
-use Drahak\Restful\InvalidArgumentException;
 use Drahak\Restful\Mapping\IMapper;
 use Nette\Application\IResponse;
-use Nette\Http\IRequest;
-use Nette\Object;
+use Nette\SmartObject;
 
 /**
  * BaseResponse
@@ -15,9 +13,12 @@ use Nette\Object;
  *
  *  @property-read string $contentType
  *  @property-write IMapper $mapper
+ * @property boolean $prettyPrint
  */
-abstract class BaseResponse extends Object implements IResponse
+abstract class BaseResponse implements IResponse
 {
+
+    use SmartObject;
 
 	/** @var array|\stdClass|\Traversable */
 	protected $data;

--- a/src/Drahak/Restful/Application/Responses/ErrorResponse.php
+++ b/src/Drahak/Restful/Application/Responses/ErrorResponse.php
@@ -4,9 +4,19 @@ namespace Drahak\Restful\Application\Responses;
 
 use Nette\Application\IResponse;
 use Nette\Http;
-use Nette\Object;
+use Nette\SmartObject;
 
-class ErrorResponse extends Object implements IResponse {
+/**
+ * Class ErrorResponse
+ * @package Drahak\Restful\Application\Responses
+ *
+ * @property-read array|\stdClass|\Traversable $data
+ * @property-read string $contentType
+ * @property-read int $code
+ */
+class ErrorResponse implements IResponse {
+
+    use SmartObject;
 
 	private $response;
 
@@ -42,7 +52,7 @@ class ErrorResponse extends Object implements IResponse {
 
 	/**
 	 * Get response data
-	 * @return array|\stdClass|\Traversable
+	 * @return int
 	 */
 	public function getCode()
 	{

--- a/src/Drahak/Restful/Application/Responses/NullResponse.php
+++ b/src/Drahak/Restful/Application/Responses/NullResponse.php
@@ -2,16 +2,18 @@
 namespace Drahak\Restful\Application\Responses;
 
 use Nette\Application\IResponse;
-use Nette\Object;
 use Nette\Http;
+use Nette\SmartObject;
 
 /**
  * NullResponse
  * @package Drahak\Restful\Responses
  * @author Drahomír Hanák
  */
-class NullResponse extends Object implements IResponse
+class NullResponse implements IResponse
 {
+
+    use SmartObject;
 
 	/**
 	 * Do nothing

--- a/src/Drahak/Restful/Application/RouteAnnotation.php
+++ b/src/Drahak/Restful/Application/RouteAnnotation.php
@@ -1,11 +1,10 @@
 <?php
 namespace Drahak\Restful\Application;
 
-use Nette\Object;
-use Nette\Utils\Strings;
 use Nette\Reflection\Method;
 use Nette\Http\IRequest;
 use Drahak\Restful\InvalidArgumentException;
+use Nette\SmartObject;
 
 /**
  * RouteAnnotation
@@ -14,8 +13,10 @@ use Drahak\Restful\InvalidArgumentException;
  *
  * @property-read string[] $methods
  */
-class RouteAnnotation extends Object implements IAnnotationParser
+class RouteAnnotation implements IAnnotationParser
 {
+
+    use SmartObject;
 
 	/** @var array */
 	private $methods = array(

--- a/src/Drahak/Restful/Application/RouteListFactory.php
+++ b/src/Drahak/Restful/Application/RouteListFactory.php
@@ -1,17 +1,15 @@
 <?php
 namespace Drahak\Restful\Application;
 
-use Nette\Object;
-use Nette\DI\Container;
 use Nette\Caching\IStorage;
 use Nette\Loaders\RobotLoader;
 use Nette\Reflection\Method;
 use Nette\Reflection\ClassType;
 use Drahak\Restful\Utils\Strings;
 use Drahak\Restful\InvalidStateException;
-use Drahak\Restful\Application\RouteAnnotation;
 use Drahak\Restful\Application\Routes\ResourceRoute;
 use Drahak\Restful\Application\Routes\ResourceRouteList;
+use Nette\SmartObject;
 
 /**
  * RouteListFactory
@@ -21,8 +19,10 @@ use Drahak\Restful\Application\Routes\ResourceRouteList;
  * @property-write string $module
  * @property-write string $prefix
  */
-class RouteListFactory extends Object implements IRouteListFactory
+class RouteListFactory implements IRouteListFactory
 {
+
+    use SmartObject;
 
 	/** @var RobotLoader */
 	private $loader;

--- a/src/Drahak/Restful/Application/Routes/StrictRoute.php
+++ b/src/Drahak/Restful/Application/Routes/StrictRoute.php
@@ -1,14 +1,13 @@
 <?php
 namespace Drahak\Restful\Application\Routes;
 
-use Nette\Object;
 use Nette\Application\IRouter;
 use Nette\Application\Routers\Route;
 use Nette\Http;
 use Nette\Http\Url;
+use Nette\SmartObject;
 use Nette\Utils\Strings;
 use Nette\Application;
-use Drahak\Restful\Application\IResourceRouter;
 
 /**
  * API strict route 
@@ -16,8 +15,10 @@ use Drahak\Restful\Application\IResourceRouter;
  * - contrtructs app request to <Module>:<Presenter>:read<Relation[0]><Relation[1]>(<RelationId[0]>, <RelationId[1]>, ...)
  * @author Drahomír Hanák
  */
-class StrictRoute extends Object implements IRouter
+class StrictRoute implements IRouter
 {
+
+    use SmartObject;
 
 	/** @var string */
 	protected $prefix;

--- a/src/Drahak/Restful/Application/UI/ResourcePresenter.php
+++ b/src/Drahak/Restful/Application/UI/ResourcePresenter.php
@@ -27,6 +27,8 @@ use Nette\Http;
  * Base presenter for REST API presenters
  * @package Drahak\Restful\Application
  * @author Drahomír Hanák
+ *
+ * @property-read IInput $input
  */
 abstract class ResourcePresenter extends UI\Presenter implements IResourcePresenter
 {

--- a/src/Drahak/Restful/ConvertedResource.php
+++ b/src/Drahak/Restful/ConvertedResource.php
@@ -6,6 +6,7 @@ use Drahak\Restful\Converters\ResourceConverter;
 /**
  * ConvertedResource
  * @package Drahak\Restful
+ *
  */
 class ConvertedResource extends Resource
 {

--- a/src/Drahak/Restful/Converters/CamelCaseConverter.php
+++ b/src/Drahak/Restful/Converters/CamelCaseConverter.php
@@ -1,16 +1,18 @@
 <?php
 namespace Drahak\Restful\Converters;
 
-use Nette\Object;
 use Drahak\Restful\Utils\Strings;
+use Nette\SmartObject;
 
 /**
  * CamelCaseConverter
  * @package Drahak\Restful\Converters
  * @author Drahomír Hanák
  */
-class CamelCaseConverter extends Object implements IConverter
+class CamelCaseConverter implements IConverter
 {
+
+    use SmartObject;
 
     /**
      * Converts resource data keys to camelCase

--- a/src/Drahak/Restful/Converters/DateTimeConverter.php
+++ b/src/Drahak/Restful/Converters/DateTimeConverter.php
@@ -1,7 +1,7 @@
 <?php
 namespace Drahak\Restful\Converters;
 
-use Nette\Object;
+use Nette\SmartObject;
 use Traversable;
 use DateTime;
 
@@ -10,8 +10,10 @@ use DateTime;
  * @package Drahak\Restful\Converters
  * @author Drahomír Hanák
  */
-class DateTimeConverter extends Object implements IConverter
+class DateTimeConverter implements IConverter
 {
+
+    use SmartObject;
 
 	/** DateTime format */
 	private $format = 'c';

--- a/src/Drahak/Restful/Converters/ObjectConverter.php
+++ b/src/Drahak/Restful/Converters/ObjectConverter.php
@@ -1,9 +1,9 @@
 <?php
 namespace Drahak\Restful\Converters;
 
+use Nette\SmartObject;
 use stdClass;
 use Traversable;
-use Nette\Object;
 use Drahak\Restful\IResource;
 
 /**
@@ -11,8 +11,10 @@ use Drahak\Restful\IResource;
  * @package Drahak\Restful\Converters
  * @author Drahomír Hanák
  */
-class ObjectConverter extends Object implements IConverter
+class ObjectConverter implements IConverter
 {
+
+    use SmartObject;
 
 	/**
 	 * Converts stdClass and traversable objects in resource to array

--- a/src/Drahak/Restful/Converters/PascalCaseConverter.php
+++ b/src/Drahak/Restful/Converters/PascalCaseConverter.php
@@ -1,16 +1,18 @@
 <?php
 namespace Drahak\Restful\Converters;
 
-use Nette\Object;
 use Drahak\Restful\Utils\Strings;
+use Nette\SmartObject;
 
 /**
  * PascalCaseConverter
  * @package Drahak\Restful\Converters
  * @author Drahomír Hanák
  */
-class PascalCaseConverter extends Object implements IConverter
+class PascalCaseConverter implements IConverter
 {
+
+    use SmartObject;
 
 	/**
 	 * Converts resource data keys to PascalCase

--- a/src/Drahak/Restful/Converters/ResourceConverter.php
+++ b/src/Drahak/Restful/Converters/ResourceConverter.php
@@ -1,7 +1,8 @@
 <?php
 namespace Drahak\Restful\Converters;
 
-use Nette\Object;
+use Nette\SmartObject;
+
 
 /**
  * ResourceConverter
@@ -9,8 +10,10 @@ use Nette\Object;
  *
  * @property-read IConverter[] $converters
  */
-class ResourceConverter extends Object
+class ResourceConverter
 {
+
+    use SmartObject;
 
 	/** @var IConverter[] */
 	private $converters = array();

--- a/src/Drahak/Restful/Converters/SnakeCaseConverter.php
+++ b/src/Drahak/Restful/Converters/SnakeCaseConverter.php
@@ -2,15 +2,17 @@
 namespace Drahak\Restful\Converters;
 
 use Drahak\Restful\Utils\Strings;
-use Nette\Object;
+use Nette\SmartObject;
 
 /**
  * SnakeCaseConverter
  * @package Drahak\Restful\Converters
  * @author Drahomír Hanák
  */
-class SnakeCaseConverter extends Object implements IConverter
+class SnakeCaseConverter implements IConverter
 {
+
+    use SmartObject;
 
     /**
      * Converts resource data keys to snake_case

--- a/src/Drahak/Restful/Diagnostics/ResourceRouterPanel.php
+++ b/src/Drahak/Restful/Diagnostics/ResourceRouterPanel.php
@@ -1,12 +1,12 @@
 <?php
 namespace Drahak\Restful\Diagnostics;
 
+use Nette\SmartObject;
 use Traversable;
 use Drahak\Restful\Application\IResourceRouter;
 use Nette\Application\IRouter;
 use Nette\Templating\Helpers;
 use Tracy\IBarPanel;
-use Nette\Object;
 use Nette\Utils\Html;
 
 if (!interface_exists('Tracy\IBarPanel')) {
@@ -18,8 +18,10 @@ if (!interface_exists('Tracy\IBarPanel')) {
  * @package Drahak\Restful\Diagnostics
  * @author Drahomír Hanák
  */
-class ResourceRouterPanel extends Object implements IBarPanel
+class ResourceRouterPanel implements IBarPanel
 {
+
+    use SmartObject;
 
 	/** @var IRouter */
 	private $router;

--- a/src/Drahak/Restful/Http/Input.php
+++ b/src/Drahak/Restful/Http/Input.php
@@ -3,15 +3,11 @@ namespace Drahak\Restful\Http;
 
 use ArrayIterator;
 use IteratorAggregate;
-use Nette\Object;
-use Nette\Http;
-use Nette\Utils\Json;
-use Nette\Utils\Strings;
-use Nette\MemberAccessException;
 use Drahak\Restful\Validation\IDataProvider;
 use Drahak\Restful\Validation\IField;
 use Drahak\Restful\Validation\IValidationScope;
 use Drahak\Restful\Validation\IValidationScopeFactory;
+use Nette\SmartObject;
 
 /**
  * Request Input parser
@@ -20,8 +16,10 @@ use Drahak\Restful\Validation\IValidationScopeFactory;
  *
  * @property array $data
  */
-class Input extends Object implements IteratorAggregate, IInput, IDataProvider
+class Input implements IteratorAggregate, IInput, IDataProvider
 {
+
+    use SmartObject;
 
 	/** @var array */
 	private $data;

--- a/src/Drahak/Restful/Http/InputFactory.php
+++ b/src/Drahak/Restful/Http/InputFactory.php
@@ -8,7 +8,6 @@ use Drahak\Restful\Mapping\MappingException;
 use Drahak\Restful\Validation\IValidationScopeFactory;
 use Drahak\Restful\Application\BadRequestException;
 use Nette\Http\IRequest;
-use Nette\Object;
 use Nette;
 
 /**
@@ -16,8 +15,10 @@ use Nette;
  * @package Drahak\Restful\Http
  * @author Drahomír Hanák
  */
-class InputFactory extends Object
+class InputFactory
 {
+
+    use Nette\SmartObject;
 
 	/** @var IRequest */
 	protected $httpRequest;

--- a/src/Drahak/Restful/Http/ResponseFactory.php
+++ b/src/Drahak/Restful/Http/ResponseFactory.php
@@ -7,8 +7,7 @@ use Drahak\Restful\InvalidStateException;
 use Nette\Http\IResponse;
 use Nette\Http\IRequest;
 use Nette\Http\Response;
-use Nette\Http\Url;
-use Nette\Object;
+use Nette\SmartObject;
 use Nette\Utils\Paginator;
 
 /**
@@ -16,8 +15,10 @@ use Nette\Utils\Paginator;
  * @package Drahak\Restful\Http
  * @author Drahomír Hanák
  */
-class ResponseFactory extends Object
+class ResponseFactory
 {
+
+    use SmartObject;
 
 	/** @var IRequest */
 	private $request;

--- a/src/Drahak/Restful/Mapping/DataUrlMapper.php
+++ b/src/Drahak/Restful/Mapping/DataUrlMapper.php
@@ -2,7 +2,7 @@
 namespace Drahak\Restful\Mapping;
 
 use Drahak\Restful\Resource\Media;
-use Nette\Object;
+use Nette\SmartObject;
 use Nette\Templating\Helpers;
 use Nette\Utils\Strings;
 use Drahak\Restful\InvalidArgumentException;
@@ -12,8 +12,10 @@ use Drahak\Restful\InvalidArgumentException;
  * @package Drahak\Restful\Mapping
  * @author Drahomír Hanák
  */
-class DataUrlMapper extends Object implements IMapper
+class DataUrlMapper implements IMapper
 {
+
+    use SmartObject;
 
 	/**
 	 * Create DATA URL from file

--- a/src/Drahak/Restful/Mapping/JsonMapper.php
+++ b/src/Drahak/Restful/Mapping/JsonMapper.php
@@ -1,7 +1,7 @@
 <?php
 namespace Drahak\Restful\Mapping;
 
-use Nette\Object;
+use Nette\SmartObject;
 use Nette\Utils\Json;
 use Nette\Utils\JsonException;
 
@@ -10,8 +10,10 @@ use Nette\Utils\JsonException;
  * @package Drahak\Restful\Mapping
  * @author Drahomír Hanák
  */
-class JsonMapper extends Object implements IMapper
+class JsonMapper implements IMapper
 {
+
+    use SmartObject;
 
 	/**
 	 * Convert array or Traversable input to string output response

--- a/src/Drahak/Restful/Mapping/MapperContext.php
+++ b/src/Drahak/Restful/Mapping/MapperContext.php
@@ -1,7 +1,7 @@
 <?php
 namespace Drahak\Restful\Mapping;
 
-use Nette\Object;
+use Nette\SmartObject;
 use Nette\Utils\Strings;
 use Drahak\Restful\InvalidStateException;
 
@@ -10,8 +10,10 @@ use Drahak\Restful\InvalidStateException;
  * @package Drahak\Restful\Mapping
  * @author Drahomír Hanák
  */
-class MapperContext extends Object
+class MapperContext
 {
+
+    use SmartObject;
 
 	/** @var array */
 	protected $services = array();

--- a/src/Drahak/Restful/Mapping/NullMapper.php
+++ b/src/Drahak/Restful/Mapping/NullMapper.php
@@ -1,15 +1,17 @@
 <?php
 namespace Drahak\Restful\Mapping;
 
-use Nette\Object;
+use Nette\SmartObject;
 
 /**
  * NullMapper
  * @package Drahak\Restful\Mapping
  * @author Drahomír Hanák
  */
-class NullMapper extends Object implements IMapper
+class NullMapper implements IMapper
 {
+
+    use SmartObject;
 
 	/**
 	 * Convert array or Traversable input to string output response

--- a/src/Drahak/Restful/Mapping/QueryMapper.php
+++ b/src/Drahak/Restful/Mapping/QueryMapper.php
@@ -1,17 +1,17 @@
 <?php
 namespace Drahak\Restful\Mapping;
 
-use Nette\Object;
-use Nette\Http\Url;
-use Nette\Utils\Strings;
+use Nette\SmartObject;
 
 /**
  * Query string mapper
  * @package Drahak\Restful\Mapping
  * @author Drahomír Hanák
  */
-class QueryMapper extends Object implements IMapper
+class QueryMapper implements IMapper
 {
+
+    use SmartObject;
 
 	/**
 	 * Convert array or Traversable input to string output response

--- a/src/Drahak/Restful/Mapping/XmlMapper.php
+++ b/src/Drahak/Restful/Mapping/XmlMapper.php
@@ -2,9 +2,8 @@
 namespace Drahak\Restful\Mapping;
 
 use DOMDocument;
+use Nette\SmartObject;
 use Traversable;
-use SimpleXMLElement;
-use Nette\Object;
 use Nette\Utils\Json;
 use Nette\Utils\Arrays;
 use Nette\Utils\JsonException;
@@ -17,8 +16,10 @@ use Drahak\Restful\InvalidArgumentException;
  *
  * @property string|NULL $rootElement
  */
-class XmlMapper extends Object implements IMapper
+class XmlMapper implements IMapper
 {
+
+    use SmartObject;
 
 	/** @internal */
 	const ITEM_ELEMENT = 'item';

--- a/src/Drahak/Restful/Resource.php
+++ b/src/Drahak/Restful/Resource.php
@@ -2,10 +2,10 @@
 namespace Drahak\Restful;
 
 use ArrayAccess;
+use Nette\SmartObject;
 use Serializable;
 use ArrayIterator;
 use IteratorAggregate;
-use Nette\Object;
 use Nette\Utils\Json;
 use Nette\MemberAccessException;
 
@@ -17,8 +17,15 @@ use Nette\MemberAccessException;
  * @property string $contentType Allowed result content type
  * @property-read array $data
  */
-class Resource extends Object implements ArrayAccess, Serializable, IteratorAggregate, IResource
+class Resource implements ArrayAccess, Serializable, IteratorAggregate, IResource
 {
+
+    use SmartObject {
+        SmartObject::__get as SO__get;
+        SmartObject::__set as SO__set;
+        SmartObject::__isset as SO__isset;
+        SmartObject::__unset as SO__unset;
+    }
 
 
 	/** @var array */
@@ -133,7 +140,7 @@ class Resource extends Object implements ArrayAccess, Serializable, IteratorAggr
 	public function &__get($name)
 	{
 		try {
-			return parent::__get($name);
+		    return $this->SO__get($name);
 		} catch (MemberAccessException $e) {
 			if (isset($this->data[$name])) {
 				return $this->data[$name];
@@ -151,7 +158,7 @@ class Resource extends Object implements ArrayAccess, Serializable, IteratorAggr
 	public function __set($name, $value)
 	{
 		try {
-			parent::__set($name, $value);
+            $this->SO__set($name, $value);
 		} catch (MemberAccessException $e) {
 			$this->data[$name] = $value;
 		}
@@ -164,7 +171,7 @@ class Resource extends Object implements ArrayAccess, Serializable, IteratorAggr
 	 */
 	public function __isset($name)
 	{
-		return !parent::__isset($name) ? isset($this->data[$name]) : TRUE;
+		return !$this->SO__isset($name) ? isset($this->data[$name]) : TRUE;
 	}
 
 	/**
@@ -175,7 +182,7 @@ class Resource extends Object implements ArrayAccess, Serializable, IteratorAggr
 	public function __unset($name)
 	{
 		try {
-			parent::__unset($name);
+		    $this->SO__unset($name);
 		} catch (MemberAccessException $e) {
 			if (isset($this->data[$name])) {
 				unset($this->data[$name]);

--- a/src/Drahak/Restful/Resource/Link.php
+++ b/src/Drahak/Restful/Resource/Link.php
@@ -1,19 +1,22 @@
 <?php
 namespace Drahak\Restful\Resource;
 
-use Nette\Object;
 use Drahak\Restful\IResource;
+use Nette\SmartObject;
 
 /**
  * Link representation in resource
  * @package Drahak\Restful\Resource
  * @author Drahomír Hanák
  *
- * @property-read string $href
- * @property-read string $rel
+ * @property string $href
+ * @property string $rel
+ * @property-read array $data
  */
-class Link extends Object implements IResource
+class Link implements IResource
 {
+
+    use SmartObject;
 
 	/** Link pointing on self */
 	const SELF = 'self';

--- a/src/Drahak/Restful/Resource/Media.php
+++ b/src/Drahak/Restful/Resource/Media.php
@@ -1,8 +1,7 @@
 <?php
 namespace Drahak\Restful\Resource;
 
-use Nette\Object;
-use Nette\Templating\Helpers;
+use Nette\SmartObject;
 use Nette\Utils\MimeTypeDetector;
 
 /**
@@ -13,8 +12,10 @@ use Nette\Utils\MimeTypeDetector;
  * @property-read string $content
  * @property-read string $contentType
  */
-class Media extends Object
+class Media
 {
+
+    use SmartObject;
 
 	/** @var string */
 	private $content;

--- a/src/Drahak/Restful/ResourceFactory.php
+++ b/src/Drahak/Restful/ResourceFactory.php
@@ -2,17 +2,18 @@
 namespace Drahak\Restful;
 
 use Drahak\Restful\Converters\ResourceConverter;
-use Drahak\Restful\Utils\Strings;
 use Nette\Http\IRequest;
-use Nette\Object;
+use Nette\SmartObject;
 
 /**
  * ResourceFactory
  * @package Drahak\Restful
  * @author Drahomír Hanák
  */
-class ResourceFactory extends Object implements IResourceFactory
+class ResourceFactory implements IResourceFactory
 {
+
+    use SmartObject;
 
 	/** @var IRequest */
 	private $request;

--- a/src/Drahak/Restful/Security/Authentication/HashAuthenticator.php
+++ b/src/Drahak/Restful/Security/Authentication/HashAuthenticator.php
@@ -5,15 +5,19 @@ use Drahak\Restful\Http\IInput;
 use Drahak\Restful\Security\IAuthTokenCalculator;
 use Drahak\Restful\Security\AuthenticationException;
 use Nette\Http\IRequest;
-use Nette\Object;
+use Nette\SmartObject;
 
 /**
  * Verify request hashing data and comparing the results
  * @package Drahak\Restful\Security\Authentication
  * @author Drahomír Hanák
+ *
+ * @property-read string $requestedHash
  */
-class HashAuthenticator extends Object implements IRequestAuthenticator
+class HashAuthenticator implements IRequestAuthenticator
 {
+
+    use SmartObject;
 
 	/** Auth token request header name */
 	const AUTH_HEADER = 'X-HTTP-AUTH-TOKEN';

--- a/src/Drahak/Restful/Security/Authentication/TimeoutAuthenticator.php
+++ b/src/Drahak/Restful/Security/Authentication/TimeoutAuthenticator.php
@@ -1,17 +1,19 @@
 <?php
 namespace Drahak\Restful\Security\Authentication;
 
-use Nette\Object;
 use Drahak\Restful\Http\IInput;
 use Drahak\Restful\Security\RequestTimeoutException;
+use Nette\SmartObject;
 
 /**
  * Verify request timeout to avoid replay attack (needs to be applied with any HashAuthenticator)
  * @package Drahak\Restful\Security\Authentication
  * @author Drahomír Hanák
  */
-class TimeoutAuthenticator extends Object implements IRequestAuthenticator
+class TimeoutAuthenticator implements IRequestAuthenticator
 {
+
+    use SmartObject;
 
 	/** @var string */
 	private $requestTimeKey;

--- a/src/Drahak/Restful/Security/AuthenticationContext.php
+++ b/src/Drahak/Restful/Security/AuthenticationContext.php
@@ -3,15 +3,18 @@ namespace Drahak\Restful\Security;
 
 use Drahak\Restful\Http\IInput;
 use Drahak\Restful\Security\Process\AuthenticationProcess;
-use Nette\Object;
+use Nette\SmartObject;
 
 /**
  * AuthenticationContext determines which authentication process should use
  * @package Drahak\Restful\Security
  * @author Drahomír Hanák
+ * @property-write AuthenticationProcess $process
  */
-class AuthenticationContext extends Object
+class AuthenticationContext
 {
+
+    use SmartObject;
 
 	/** @var AuthenticationProcess */
 	private $process;

--- a/src/Drahak/Restful/Security/HashCalculator.php
+++ b/src/Drahak/Restful/Security/HashCalculator.php
@@ -5,8 +5,8 @@ use Drahak\Restful\Http\IInput;
 use Drahak\Restful\InvalidStateException;
 use Drahak\Restful\Mapping\IMapper;
 use Drahak\Restful\Mapping\MapperContext;
-use Nette\Object;
 use Nette\Http\IRequest;
+use Nette\SmartObject;
 
 /**
  * Default auth token calculator implementation
@@ -15,8 +15,10 @@ use Nette\Http\IRequest;
  *
  * @property-write string $privateKey
  */
-class HashCalculator extends Object implements IAuthTokenCalculator
+class HashCalculator implements IAuthTokenCalculator
 {
+
+    use SmartObject;
 
 	/** Fingerprint hash algorithm */
 	const HASH = 'sha256';

--- a/src/Drahak/Restful/Security/Process/AuthenticationProcess.php
+++ b/src/Drahak/Restful/Security/Process/AuthenticationProcess.php
@@ -1,16 +1,18 @@
 <?php
 namespace Drahak\Restful\Security\Process;
 
-use Nette\Object;
 use Drahak\Restful\Http\IInput;
+use Nette\SmartObject;
 
 /**
  * Request AuthenticationProcess template
  * @package Drahak\Restful\Security\Process
  * @author Drahomír Hanák
  */
-abstract class AuthenticationProcess extends Object
+abstract class AuthenticationProcess
 {
+
+    use SmartObject;
 
 	/**
 	 * Authenticate process

--- a/src/Drahak/Restful/Utils/RequestFilter.php
+++ b/src/Drahak/Restful/Utils/RequestFilter.php
@@ -1,8 +1,7 @@
 <?php
 namespace Drahak\Restful\Utils;
 
-use Nette\Object;
-use Nette\ArrayList;
+use Nette\SmartObject;
 use Nette\Utils\Paginator;
 use Drahak\Restful\InvalidStateException;
 use Nette\Http\IRequest;
@@ -17,8 +16,10 @@ use Nette\Http\IRequest;
  * @property-read string $searchQuery
  * @property-read Paginator $paginator
  */
-class RequestFilter extends Object
+class RequestFilter
 {
+
+    use SmartObject;
 
 	/** Fields key in URL query */
 	const FIELDS_KEY = 'fields';

--- a/src/Drahak/Restful/Validation/Error.php
+++ b/src/Drahak/Restful/Validation/Error.php
@@ -1,9 +1,9 @@
 <?php
 namespace Drahak\Restful\Validation;
 
-use Nette\Object;
 use IteratorAggregate;
 use ArrayIterator;
+use Nette\SmartObject;
 use Traversable;
 
 /**
@@ -15,8 +15,10 @@ use Traversable;
  * @property-read string $message
  * @property-read int $code
  */
-class Error extends Object implements IteratorAggregate
+class Error implements IteratorAggregate
 {
+
+    use SmartObject;
 
 	/** @var string */
 	private $field;

--- a/src/Drahak/Restful/Validation/Field.php
+++ b/src/Drahak/Restful/Validation/Field.php
@@ -1,7 +1,7 @@
 <?php
 namespace Drahak\Restful\Validation;
 
-use Nette\Object;
+use Nette\SmartObject;
 use Nette\Utils\Validators;
 
 /**
@@ -13,8 +13,10 @@ use Nette\Utils\Validators;
  * @property-read Rule[] $rules
  * @property-read IValidator $validator
  */
-class Field extends Object implements IField
+class Field implements IField
 {
+
+    use SmartObject;
 
 	/** @var array Default field error messages for validator */
 	public static $defaultMessages = array(

--- a/src/Drahak/Restful/Validation/Rule.php
+++ b/src/Drahak/Restful/Validation/Rule.php
@@ -1,10 +1,7 @@
 <?php
 namespace Drahak\Restful\Validation;
 
-use Nette\Object;
-use Nette\Forms\Form;
-use Nette\Utils\Strings;
-use Nette\Utils\Validators;
+use Nette\SmartObject;
 
 /**
  * Validation Rule caret
@@ -17,8 +14,10 @@ use Nette\Utils\Validators;
  * @property string $expression
  * @property array $argument
  */
-class Rule extends Object
+class Rule
 {
+
+    use SmartObject;
 
 	/** @var string */
 	protected $field;

--- a/src/Drahak/Restful/Validation/ValidationScope.php
+++ b/src/Drahak/Restful/Validation/ValidationScope.php
@@ -1,7 +1,7 @@
 <?php
 namespace Drahak\Restful\Validation;
 
-use Nette\Object;
+use Nette\SmartObject;
 use Nette\Utils\Validators;
 use Nette\Utils\Strings;
 
@@ -11,9 +11,12 @@ use Nette\Utils\Strings;
  * @author Drahomír Hanák
  *
  * @property-read IValidator $validator
+ * @property-read Field[] $fields
  */
-class ValidationScope extends Object implements IValidationScope
+class ValidationScope implements IValidationScope
 {
+
+    use SmartObject;
 
 	/** @var IValidator */
 	private $validator;

--- a/src/Drahak/Restful/Validation/ValidationScopeFactory.php
+++ b/src/Drahak/Restful/Validation/ValidationScopeFactory.php
@@ -1,15 +1,17 @@
 <?php
 namespace Drahak\Restful\Validation;
 
-use Nette\Object;
+use Nette\SmartObject;
 
 /**
  * ValidationScopeFactory
  * @package Drahak\Restful\Validation
  * @author Drahomír Hanák
  */
-class ValidationScopeFactory extends Object implements IValidationScopeFactory
+class ValidationScopeFactory implements IValidationScopeFactory
 {
+
+    use SmartObject;
 
 	/** @var IValidator */
 	private $validator;

--- a/src/Drahak/Restful/Validation/Validator.php
+++ b/src/Drahak/Restful/Validation/Validator.php
@@ -3,7 +3,7 @@ namespace Drahak\Restful\Validation;
 
 use Drahak\Restful\InvalidStateException;
 use Drahak\Restful\InvalidArgumentException;
-use Nette\Object;
+use Nette\SmartObject;
 use Nette\Utils\Strings;
 use Nette\Utils\Validators;
 
@@ -12,8 +12,10 @@ use Nette\Utils\Validators;
  * @package Drahak\Restful\Validation
  * @author Drahomír Hanák
  */
-class Validator extends Object implements IValidator
+class Validator implements IValidator
 {
+
+    use SmartObject;
 
 	/** @var array Command handle callbacks */
 	public $handle = array(


### PR DESCRIPTION
Due to PHP 7.2 compatibility of package switched from Nette\Object to Nette\SmartObject

Addresses https://github.com/drahak/Restful/issues/135

Note: package is still depndend on drahak\OAuth2, which uses Nette\Object, so using OAuth2 auth handler still does not work in PHP 7.2. All other features work.